### PR TITLE
Use PromptPay shortcode instead of static QR placeholder

### DIFF
--- a/includes/class-san8n-gateway.php
+++ b/includes/class-san8n-gateway.php
@@ -237,8 +237,7 @@ class SAN8N_Gateway extends WC_Payment_Gateway {
             echo wpautop(wp_kses_post($this->description));
         }
 
-        $order_total = WC()->cart->get_total('edit');
-        $qr_payload = $this->generate_qr_payload($order_total);
+        $order_total   = WC()->cart->get_total('edit');
         $session_token = $this->generate_session_token();
         
         ?>
@@ -246,12 +245,13 @@ class SAN8N_Gateway extends WC_Payment_Gateway {
             <div class="san8n-qr-section">
                 <h4><?php esc_html_e('Step 1: Scan PromptPay QR Code', 'scanandpay-n8n'); ?></h4>
                 <div class="san8n-qr-container">
-                    <div class="san8n-qr-placeholder" data-payload="<?php echo esc_attr($qr_payload); ?>">
-                        <img src="<?php echo esc_url(SAN8N_PLUGIN_URL . 'assets/images/qr-placeholder.png'); ?>" 
-                             alt="<?php esc_attr_e('PromptPay QR Code', 'scanandpay-n8n'); ?>" />
-                    </div>
+                    <?php
+                    if (shortcode_exists('promptpayqr')) {
+                        echo do_shortcode('[promptpayqr ppid="' . esc_attr($this->promptpay_payload) . '"]');
+                    }
+                    ?>
                     <div class="san8n-amount-display">
-                        <?php 
+                        <?php
                         echo sprintf(
                             /* translators: %s: order amount */
                             __('Amount: %s THB', 'scanandpay-n8n'),


### PR DESCRIPTION
## Summary
- Remove generated QR payload and QR placeholder markup
- Render PromptPay QR via the `promptpayqr` shortcode when available

## Testing
- `php -l includes/class-san8n-gateway.php`
- `phpcs --standard=phpcs.xml includes/class-san8n-gateway.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cacccf21c832d8599ba6837288a05