### PR TITLE
Improve small-screen layout for Scan & Pay checkout

### DIFF
--- a/assets/css/checkout.css
+++ b/assets/css/checkout.css
@@ -6,6 +6,11 @@
 #san8n-payment-fields {
     padding: 15px 0;
 }
+#san8n-payment-fields.san8n-payment-container {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+}
 
 /* QR Code Section */
 .san8n-qr-section {
@@ -34,6 +39,11 @@
     max-width: 200px;
     height: auto;
     margin: 0 auto 10px;
+    display: block;
+}
+.san8n-qr-placeholder img {
+    width: 100%;
+    height: auto;
     display: block;
 }
 
@@ -252,6 +262,40 @@
     #san8n-verify-button {
         width: 100%;
         padding: 12px 20px;
+    }
+}
+
+@media (max-width: 480px) {
+    .san8n-qr-section,
+    .san8n-upload-section { padding: 8px; }
+
+    .san8n-qr-container,
+    .san8n-upload-container { padding: 10px; }
+
+    .san8n-qr-placeholder { max-width: 130px; }
+    .san8n-amount-display { font-size: 18px; }
+
+    .san8n-upload-container input[type="file"] {
+        width: 100%;
+        box-sizing: border-box;
+    }
+
+    #san8n-verify-button {
+        width: 100%;
+        padding: 10px 16px;
+        font-size: 15px;
+    }
+}
+
+@media (max-width: 360px) {
+    .san8n-qr-placeholder { max-width: 110px; }
+    .san8n-qr-section h4,
+    .san8n-upload-section h4 { font-size: 14px; }
+    .san8n-amount-display { font-size: 16px; }
+
+    #san8n-verify-button {
+        font-size: 14px;
+        padding: 9px 14px;
     }
 }
 

--- a/includes/class-san8n-gateway.php
+++ b/includes/class-san8n-gateway.php
@@ -242,8 +242,8 @@ class SAN8N_Gateway extends WC_Payment_Gateway {
         $session_token = $this->generate_session_token();
         
         ?>
-        <div id="san8n-payment-fields" class="san8n-payment-container">
-            <div class="san8n-qr-section">
+        <fieldset id="san8n-payment-fields" class="san8n-payment-container wc-payment-form" style="background:transparent;">
+            <div class="san8n-qr-section form-row form-row-wide">
                 <h4><?php esc_html_e('Step 1: Scan PromptPay QR Code', 'scanandpay-n8n'); ?></h4>
                 <div class="san8n-qr-container">
                     <div class="san8n-qr-placeholder" data-payload="<?php echo esc_attr($qr_payload); ?>">
@@ -262,7 +262,7 @@ class SAN8N_Gateway extends WC_Payment_Gateway {
                 </div>
             </div>
 
-            <div class="san8n-upload-section">
+            <div class="san8n-upload-section form-row form-row-wide">
                 <h4><?php esc_html_e('Step 2: Upload Payment Slip', 'scanandpay-n8n'); ?></h4>
                 <div class="san8n-upload-container">
                     <input type="file" 
@@ -289,9 +289,9 @@ class SAN8N_Gateway extends WC_Payment_Gateway {
                 </div>
             </div>
 
-            <div class="san8n-verify-section">
-                <button type="button" 
-                        id="san8n-verify-button" 
+            <div class="san8n-verify-section form-row form-row-wide">
+                <button type="button"
+                        id="san8n-verify-button"
                         class="san8n-verify-button button alt"
                         disabled>
                     <?php esc_html_e('Verify Payment', 'scanandpay-n8n'); ?>
@@ -314,7 +314,7 @@ class SAN8N_Gateway extends WC_Payment_Gateway {
             <?php if ($this->auto_place_order_classic): ?>
             <input type="hidden" id="san8n-auto-submit" value="1" data-delay="<?php echo esc_attr($this->prevent_double_submit_ms); ?>" />
             <?php endif; ?>
-        </div>
+        </fieldset>
         <?php
     }
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Scan and Pay n8n">
-    <description>WordPress Coding Standards for Scan & Pay (n8n) plugin</description>
+    <description>WordPress Coding Standards for Scan &amp; Pay (n8n) plugin</description>
 
     <!-- Scan all PHP files in directory -->
     <file>.</file>

--- a/plan.md
+++ b/plan.md
@@ -11,6 +11,7 @@ Static QR (Media Library) + simplified slip verification via n8n (mock).
 - [ ] Remove dynamic-price/cart-hash resets
 - [ ] Bump version + add readme.txt changelog
 - [ ] Update docs: context.md, AGENTS.md, plan.md
+- [x] Improve small-screen responsive layout for payment UI
 
 ## Risks/Mitigations
 - Blocks vs Classic → ship Classic first; gate others

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, payment gateway, promptpay, qr code, thailand
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 8.0
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -183,6 +183,9 @@ Yes, administrators can manually approve or reject payments from the order edit 
 
 == Changelog ==
 
+= 1.0.1 - 2025-08-16 =
+* Improved small-screen responsive layout for Scan & Pay checkout
+
 = 1.0.0 =
 * Initial release
 * Classic checkout support with auto-submit
@@ -194,6 +197,9 @@ Yes, administrators can manually approve or reject payments from the order edit 
 * Full i18n and RTL support
 
 == Upgrade Notice ==
+
+= 1.0.1 =
+Improved small-screen responsive layout for Scan & Pay checkout.
 
 = 1.0.0 =
 Initial release of Scan & Pay (n8n) payment gateway for WooCommerce.

--- a/scanandpay-n8n.php
+++ b/scanandpay-n8n.php
@@ -3,7 +3,7 @@
  * Plugin Name: Scan & Pay (n8n)
  * Plugin URI: https://github.com/your-org/scanandpay-n8n
  * Description: PromptPay payment gateway with inline slip verification via n8n
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Your Company
  * Author URI: https://yourcompany.com
  * Text Domain: scanandpay-n8n
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('SAN8N_VERSION', '1.0.0');
+define('SAN8N_VERSION', '1.0.1');
 define('SAN8N_PLUGIN_FILE', __FILE__);
 define('SAN8N_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('SAN8N_PLUGIN_URL', plugin_dir_url(__FILE__));


### PR DESCRIPTION
## Summary
- make QR image responsive and extend small-screen breakpoints for checkout styles
- wrap Scan & Pay payment fields with WooCommerce form-row classes for responsive layout
- bump plugin version to 1.0.1 and document responsive improvements

## Testing
- `phpcs -q --report=summary includes/class-san8n-gateway.php scanandpay-n8n.php` *(fails: existing coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a00da59490832db565ebd84820b784