### PR TITLE
Ensure PromptPay shortcode and assets load with fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Rules and map for agents (Codex/Windsurf/Cursor) to work safely on this WooComme
 - Remove custom QR payload logic (`generate_qr_payload`) and any `promptpay_payload` usage
 - Keep security: nonce, file type/size, strip EXIF, caps
 - Classic checkout: renders live QR via shortcode in `payment_fields()` with fallback SVG if shortcode missing
-- Blocks checkout: currently shows a static placeholder image; optional enhancement is to render a `.ppy-card` with PromptPay JS
+- Blocks checkout: placeholder by default; live QR can be enabled via `san8n_blocks_live_qr` filter which renders a `.ppy-card` initialized by PromptPay JS
 
 ## API (internal → n8n)
 POST /wp-json/wc-scanandpay/v1/verify-slip  (multipart)
@@ -51,5 +51,5 @@ n8n → { status: approved|rejected, reference_id?, approved_amount?, reason? }
 
 ## Roadmap
 - Medium term: Re-render QR on `update_checkout` via AJAX to fetch refreshed shortcode HTML so the locked amount always matches the latest total
-- Short/medium: Improve Blocks integration to render live QR (initialize `.ppy-card` using PromptPay JS); today it's a placeholder
+- Short/medium: Improve Blocks integration to render live QR by default; currently gated via `san8n_blocks_live_qr` filter
 - Long term: Add WooCommerce Blocks support (separate integration path; React-based, not `payment_fields()`)

--- a/assets/js/blocks-integration.js
+++ b/assets/js/blocks-integration.js
@@ -12,6 +12,15 @@ const settings = getSetting('scanandpay_n8n_data', {});
 const label = decodeEntities(settings.title) || __('Scan & Pay (n8n)', 'scanandpay-n8n');
 const description = decodeEntities(settings.description || '');
 
+// Initialize PromptPay JS when live QR is enabled
+if (settings.settings && settings.settings.live_qr) {
+    document.addEventListener('DOMContentLoaded', () => {
+        if (window.PromptPay && typeof window.PromptPay.init === 'function') {
+            window.PromptPay.init();
+        }
+    });
+}
+
 const SAN8N_BlocksContent = ({ eventRegistration, emitResponse }) => {
     const { onPaymentSetup, onCheckoutValidation } = eventRegistration;
     const [slipFile, setSlipFile] = useState(null);
@@ -25,6 +34,12 @@ const SAN8N_BlocksContent = ({ eventRegistration, emitResponse }) => {
 
     // Get cart total
     const cartTotal = window.wc.wcBlocksData.getSetting('cartTotals', {}).total_price / 100;
+
+    useEffect(() => {
+        if (settings.settings && settings.settings.live_qr && window.PromptPay && typeof window.PromptPay.init === 'function') {
+            window.PromptPay.init();
+        }
+    }, [cartTotal]);
 
     useEffect(() => {
         // Handle payment setup
@@ -186,11 +201,18 @@ const SAN8N_BlocksContent = ({ eventRegistration, emitResponse }) => {
             <div className="san8n-qr-section">
                 <h4>{settings.i18n.scan_qr}</h4>
                 <div className="san8n-qr-container">
-                    <img 
-                        src={settings.settings.qr_placeholder} 
-                        alt="PromptPay QR Code"
-                        className="san8n-qr-placeholder"
-                    />
+                    {settings.settings.live_qr ? (
+                        <div
+                            className="ppy-card"
+                            data-amount={cartTotal.toFixed(2)}
+                        ></div>
+                    ) : (
+                        <img
+                            src={settings.settings.qr_placeholder}
+                            alt="PromptPay QR Code"
+                            className="san8n-qr-placeholder"
+                        />
+                    )}
                     <div className="san8n-amount-display">
                         {settings.i18n.amount_label.replace('%s', cartTotal.toFixed(2))}
                     </div>

--- a/includes/class-san8n-blocks-integration.php
+++ b/includes/class-san8n-blocks-integration.php
@@ -53,6 +53,21 @@ final class SAN8N_Blocks_Integration extends AbstractPaymentMethodType {
             SAN8N_VERSION
         );
 
+        // Optionally load PromptPay assets for live QR in Blocks
+        if (apply_filters('san8n_blocks_live_qr', false) && shortcode_exists('promptpayqr')) {
+            if (!wp_style_is('ppy-main-style', 'enqueued') && !wp_style_is('ppy-main-style', 'registered')) {
+                wp_enqueue_style('ppy-main-style', SAN8N_PLUGIN_URL . 'promptpay/css/main.css', array(), SAN8N_VERSION);
+            } else {
+                wp_enqueue_style('ppy-main-style');
+            }
+
+            if (!wp_script_is('ppy-main-script', 'enqueued') && !wp_script_is('ppy-main-script', 'registered')) {
+                wp_enqueue_script('ppy-main-script', SAN8N_PLUGIN_URL . 'promptpay/js/main.min.js', array('jquery'), SAN8N_VERSION, true);
+            } else {
+                wp_enqueue_script('ppy-main-script');
+            }
+        }
+
         return array('san8n-blocks-integration');
     }
 
@@ -69,7 +84,8 @@ final class SAN8N_Blocks_Integration extends AbstractPaymentMethodType {
                 'show_express_only_when_approved' => $this->get_setting('show_express_only_when_approved', 'yes') === 'yes',
                 'prevent_double_submit_ms' => intval($this->get_setting('prevent_double_submit_ms', '1500')),
                 'max_file_size' => intval($this->get_setting('max_file_size', '5')) * 1024 * 1024,
-                'qr_placeholder' => SAN8N_PLUGIN_URL . 'assets/images/qr-placeholder.svg'
+                'qr_placeholder' => SAN8N_PLUGIN_URL . 'assets/images/qr-placeholder.svg',
+                'live_qr' => apply_filters('san8n_blocks_live_qr', false)
             ),
             'rest_url' => rest_url(SAN8N_REST_NAMESPACE),
             'nonce' => wp_create_nonce('san8n-verify'),

--- a/includes/class-san8n-gateway.php
+++ b/includes/class-san8n-gateway.php
@@ -313,6 +313,21 @@ class SAN8N_Gateway extends WC_Payment_Gateway {
         );
         wp_enqueue_style('san8n-checkout');
 
+        // Ensure PromptPay assets when shortcode is available
+        if (shortcode_exists('promptpayqr')) {
+            if (!wp_style_is('ppy-main-style', 'enqueued') && !wp_style_is('ppy-main-style', 'registered')) {
+                wp_enqueue_style('ppy-main-style', SAN8N_PLUGIN_URL . 'promptpay/css/main.css', array(), SAN8N_VERSION);
+            } else {
+                wp_enqueue_style('ppy-main-style');
+            }
+
+            if (!wp_script_is('ppy-main-script', 'enqueued') && !wp_script_is('ppy-main-script', 'registered')) {
+                wp_enqueue_script('ppy-main-script', SAN8N_PLUGIN_URL . 'promptpay/js/main.min.js', array('jquery'), SAN8N_VERSION, true);
+            } else {
+                wp_enqueue_script('ppy-main-script');
+            }
+        }
+
         // Register and enqueue scripts
         wp_register_script(
             'san8n-checkout-inline',

--- a/plan.md
+++ b/plan.md
@@ -1,33 +1,28 @@
-# plan.md — Sprint Plan (2025-08-17)
+# plan.md — Sprint Plan (2025-08-25)
 
 ## Goal
-Use PromptPay shortcode to render QR with locked amount (ID from PromptPay plugin settings). Simplify slip verification payload and remove custom QR payload logic. Classic checkout only in this iteration.
+Fix PromptPay QR rendering on checkout; ensure shortcode and assets load automatically and maintain fallback. Prepare optional live QR path for Blocks checkout.
 
 ## Tasks
-- [x] Remove `promptpay_payload` option and any code usage
-- [x] In `payment_fields()`, output `[promptpayqr amount="{float_cart_total}"]`; do not pass `id`
-- [x] Add fallback notice + `assets/images/qr-placeholder.svg` when shortcode unavailable
-- [x] JS: send slip with {session_token, order_id, order_total} only (no cart_total/cart_hash)
-- [x] REST: accept new params; forward to n8n (mock); trust decision
-- [x] Remove legacy dynamic-price resets
-- [x] Bump version + add readme.txt changelog
-- [x] Update docs: context.md, AGENTS.md, instructions.md, evaluation.md, feedback.md, plan.md
-- [x] Improve small-screen responsive layout for payment UI
+- [x] Auto-bootstrap bundled PromptPay plugin when shortcode missing (guard against double load)
+- [x] Conditionally enqueue PromptPay CSS/JS when shortcode present
+- [x] Ensure Classic checkout renders live QR via shortcode with SVG fallback
+- [x] Add filter to optionally enable live QR on Blocks checkout
+- [x] Bump version and update changelog
 
 ## Risks/Mitigations
-- PromptPay plugin inactive → show fallback SVG + admin notice; document dependency
-- Amount formatting → always cast to float; avoid localized strings
-- Blocks vs Classic → ship Classic first; blocks tracked in roadmap
-- If shortcode is missing, auto-bootstrap bundled `promptpay/promptpay.php` to register shortcode and enqueue assets; avoid double-enqueue when external plugin is active
+- External PromptPay plugin active → use shortcode_exists/class check before bootstrapping
+- Blocks live QR disabled by default to avoid regressions
+- Shortcode missing → fallback placeholder displayed
 
 ## Acceptance Criteria
-- Checkout renders PromptPay QR via shortcode with amount locked to cart total
-- REST + JS flow works E2E with mock; payload excludes cart_total/cart_hash
-- No references to `generate_qr_payload` or `promptpay_payload`
+- Classic checkout shows live QR when PromptPay available
+- PromptPay assets only load when shortcode exists
+- Blocks integration can opt into live QR via `san8n_blocks_live_qr` filter
 - PHPCS passes
 
 ## Next
-- Medium: AJAX re-render of shortcode on `update_checkout` to keep amount in sync
-- Long: WooCommerce Blocks support (dedicated Blocks payment method)
-- Integrate real bank-API via n8n
-- Add e2e smoke tests (upload → approved)
+- AJAX re-render of shortcode on `update_checkout` for dynamic totals
+- Full Blocks React integration without feature flag
+- Real n8n/bank integration
+- Add end-to-end tests for slip verification

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, payment gateway, promptpay, qr code, thailand
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 8.0
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -182,6 +182,11 @@ Configurable retention period (default 30 days) with automatic cleanup.
 Yes, administrators can manually approve or reject payments from the order edit page.
 
 == Changelog ==
+
+= 1.1.1 - 2025-08-25 =
+* Ensure PromptPay shortcode and assets load on checkout
+* Fallback SVG shown when PromptPay plugin inactive
+* Optional filter to enable live QR in Blocks checkout
 
 = 1.1.0 - 2025-08-21 =
 * Use PromptPay shortcode for QR (amount-only)

--- a/scanandpay-n8n.php
+++ b/scanandpay-n8n.php
@@ -3,7 +3,7 @@
  * Plugin Name: Scan & Pay (n8n)
  * Plugin URI: https://github.com/your-org/scanandpay-n8n
  * Description: PromptPay payment gateway with inline slip verification via n8n
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: Your Company
  * Author URI: https://yourcompany.com
  * Text Domain: scanandpay-n8n
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('SAN8N_VERSION', '1.1.0');
+define('SAN8N_VERSION', '1.1.1');
 define('SAN8N_PLUGIN_FILE', __FILE__);
 define('SAN8N_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('SAN8N_PLUGIN_URL', plugin_dir_url(__FILE__));
@@ -33,8 +33,17 @@ define('SAN8N_SESSION_FLAG', 'san8n_approved');
 define('SAN8N_LOGGER_SOURCE', 'scanandpay-n8n');
 define('SAN8N_CAPABILITY', 'san8n_manage');
 
+// Bootstrap PromptPay shortcode if missing
+add_action('plugins_loaded', 'san8n_bootstrap_promptpay', 5);
+
 // Bootstrap plugin
 add_action('plugins_loaded', 'san8n_init_gateway', 11);
+
+function san8n_bootstrap_promptpay() {
+    if (!shortcode_exists('promptpayqr') && !class_exists('PromptPay')) {
+        include_once SAN8N_PLUGIN_DIR . 'promptpay/promptpay.php';
+    }
+}
 
 function san8n_init_gateway() {
     // Check if WooCommerce is active


### PR DESCRIPTION
## Summary
- Auto-load bundled PromptPay shortcode if missing to render QR codes
- Conditionally enqueue PromptPay CSS/JS on checkout and expose optional Blocks live QR filter
- Update docs and changelog for 1.1.1 release

## Testing
- `php -l scanandpay-n8n.php includes/class-san8n-gateway.php includes/class-san8n-blocks-integration.php`
- `~/.local/share/mise/installs/php/8.4.11/.composer/vendor/bin/phpcs -s` *(fails: numerous coding-standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e53db370832dbca051a44037e7fa