### PR TITLE
docs: preserve legacy last_seen timestamps

### DIFF
--- a/docs/migrations/2025-08-27b_backfill_approvals_idem.sql
+++ b/docs/migrations/2025-08-27b_backfill_approvals_idem.sql
@@ -17,7 +17,7 @@ BEGIN
           md5(session_token || '|' || COALESCE(ref_code,'') || '|' || approved_amount::text || '|' || EXTRACT(EPOCH FROM matched_at)::text)
         )
       ),
-      last_seen_at = COALESCE(last_seen_at, created_at)
+      last_seen_at = created_at
     WHERE source IS NULL OR idempotency_key IS NULL;
   END IF;
 END$$;

--- a/plan.md
+++ b/plan.md
@@ -10,6 +10,7 @@ Slipless PromptPay flow (no bank/PSP APIs, no fees):
 
 ## Tasks
 - [x] Update docs to slipless architecture and task breakdown
+- [x] Correct approvals backfill to preserve historical last_seen_at
 - [ ] WP REST proxy: `POST /wp-json/san8n/v1/qr/generate` (server‑side HMAC) → forward to n8n
 - [ ] WP REST proxy: `GET /wp-json/san8n/v1/order/status` → poll n8n session store
 - [ ] WP REST callback: `POST /wp-json/san8n/v1/order/paid` from n8n to mark paid/cancelled


### PR DESCRIPTION
## Summary
- set `last_seen_at` to `created_at` when backfilling legacy approvals
- note backfill fix in sprint plan

## Testing
- `ls docs/migrations/2025-08-27*.sql | shuf | xargs -n1 -I{} su postgres -c "psql -v ON_ERROR_STOP=1 -f {}"` *(fails: user postgres does not exist)*
- `psql -c "INSERT INTO approvals (source,idempotency_key,session_token,approved_amount,matched_at) VALUES ('src','key','sess',0, now()) ON CONFLICT (source,idempotency_key) DO UPDATE SET last_seen_at = EXCLUDED.last_seen_at; SELECT count(*), min(last_seen_at), max(last_seen_at) FROM approvals WHERE source='src' AND idempotency_key='key';"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afe50d9878832da0ad0ab3e94fe0ad