### PR TITLE
fix: enable Postgres onError branch for Tasker ingest

### DIFF
--- a/json/Tasker Ingest.v5.4.ai-openrouter.v3.json
+++ b/json/Tasker Ingest.v5.4.ai-openrouter.v3.json
@@ -325,7 +325,7 @@
       ],
       "notesInFlow": true,
       "notes": "Set Postgres credentials in this node. Creates/updates row by message_id.",
-      "continueOnFail": true
+      "continueOnFail": false
     },
     {
       "parameters": {


### PR DESCRIPTION
## Summary
- disable `continueOnFail` on PG Upsert Payment so Postgres errors reach Log Error

## Testing
- `jq '.' json/Tasker Ingest.v5.4.ai-openrouter.v3.json`
- `phpcs --version`


------
https://chatgpt.com/codex/tasks/task_e_68aff4a2148c832d9da042507dd55eaa