### PR TITLE
fix: drop approved_at from session match function

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,3 +9,4 @@ Entries reference session logs under `docs/sessions/`.
 - 2025-08-27 — Add source/idempotency columns with helper UPSERT for approvals table.
 - 2025-08-28 — Tasker ingest v5.4 adds error paths and structured metrics; workflow bumped to ai-openrouter v3.
 - 2025-08-28 — Add atomic session match function and consolidate Tasker ingest to single DB call (v5.5 ai-openrouter v4).
+- 2025-08-29 — Fix fn_match_and_approve_session to use status instead of non-existent approved_at column.

--- a/docs/migrations/2025-08-27e_fn_match_and_approve_session.sql
+++ b/docs/migrations/2025-08-27e_fn_match_and_approve_session.sql
@@ -12,12 +12,12 @@ CREATE OR REPLACE FUNCTION fn_match_and_approve_session(
 LANGUAGE plpgsql AS $$
 DECLARE
   v_created_at timestamptz;
-  v_approved_at timestamptz;
+  v_status text;
   v_source text;
   v_idem_key text;
   v_now timestamptz := now();
 BEGIN
-  SELECT created_at, approved_at INTO v_created_at, v_approved_at
+  SELECT created_at, status INTO v_created_at, v_status
   FROM payment_sessions
   WHERE session_token = p_session_token
   FOR UPDATE;
@@ -46,9 +46,9 @@ BEGIN
   ON CONFLICT (source, idempotency_key) DO UPDATE
     SET last_seen_at = EXCLUDED.last_seen_at;
 
-  IF v_approved_at IS NULL THEN
+  IF v_status <> 'approved' THEN
     UPDATE payment_sessions
-      SET approved_at = v_now
+      SET status = 'approved'
       WHERE session_token = p_session_token;
     RETURN QUERY SELECT true, NULL;
   ELSE

--- a/plan.md
+++ b/plan.md
@@ -21,6 +21,7 @@ Slipless PromptPay flow (no bank/PSP APIs, no fees):
 - [ ] WP gateway UI: render QR from EMV response and start polling until paid/expired
 - [ ] Security hardening: HMAC, HTTPS, payload guards, secret rotation, idempotency
 - [ ] Observability: logs, dead‑letter, metrics; tester checklist
+- [x] Fix fn_match_and_approve_session to drop unused approved_at column
 
 ## Process
 


### PR DESCRIPTION
## Summary
- replace nonexistent `approved_at` column with `status` in `fn_match_and_approve_session`
- document session approval using `status` in schema and plan
- note fix in developer changelog

## Testing
- `jq '.' json/Tasker Ingest.v5.5.ai-openrouter.v4.json`
- `psql -v ON_ERROR_STOP=1 -f docs/migrations/*.sql` *(fails: Network is unreachable)*
- `psql -c "SELECT fn_match_and_approve_session('t', now(), 600);"` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b2a91310832dbfd614758aa345b1